### PR TITLE
Cambios mejoras

### DIFF
--- a/python/main-classic/core/library.py
+++ b/python/main-classic/core/library.py
@@ -595,20 +595,8 @@ def add_pelicula_to_library(item):
     """
     logger.info()
 
-    condicion = "true"
-    import time
-    while condicion == "true":
-        condicion = config.get_setting("adding_content")
-        if str(condicion) == "":
-            condicion = "false"
-        time.sleep(0.5)
-
-    config.set_setting("adding_content", "true")
-
     new_item = item.clone(action="findvideos")
     insertados, sobreescritos, fallidos = save_library_movie(new_item)
-
-    config.set_setting("adding_content", "false")
 
     if fallidos == 0:
         platformtools.dialog_ok(config.get_localized_string(30131), new_item.contentTitle,
@@ -642,14 +630,6 @@ def add_serie_to_library(item, channel=None):
     """
     logger.info("show=#" + item.show + "#")
     # logger.debug(item.tostring('\n'))
-
-    condicion = "true"
-    import time
-    while condicion == "true":
-        condicion = config.get_setting("adding_content")
-        if str(condicion) == "":
-            condicion = "false"
-        time.sleep(0.5)
 
     if item.channel == "descargas":
         itemlist = [item.clone()]
@@ -687,11 +667,7 @@ def add_serie_to_library(item, channel=None):
                      % item.show)
         return
 
-    config.set_setting("adding_content", "true")
-
     insertados, sobreescritos, fallidos = save_library_tvshow(item, itemlist)
-
-    config.set_setting("adding_content", "false")
 
     if fallidos == -1:
         platformtools.dialog_ok("Biblioteca", "ERROR, la serie NO se ha añadido a la biblioteca")

--- a/python/main-classic/library_service.py
+++ b/python/main-classic/library_service.py
@@ -212,7 +212,6 @@ def check_for_update(overwrite=True):
     overwrite_everything = False
 
     try:
-        import xbmc
         if overwrite == "everything":
             overwrite = True
             overwrite_everything = True
@@ -225,6 +224,7 @@ def check_for_update(overwrite=True):
                 updatelibrary_wait = [0, 10000, 20000, 30000, 60000]
                 wait = updatelibrary_wait[int(config.get_setting("updatelibrary_wait", "biblioteca"))]
                 if wait > 0:
+                    import xbmc
                     xbmc.sleep(wait)
 
             heading = 'Actualizando biblioteca....'

--- a/python/main-classic/library_service.py
+++ b/python/main-classic/library_service.py
@@ -213,16 +213,6 @@ def check_for_update(overwrite=True):
 
     try:
         import xbmc
-
-        condicion = "true"
-        while condicion == "true":
-            condicion = config.get_setting("adding_content")
-            if str(condicion) == "":
-                condicion = "false"
-            xbmc.sleep(200)
-
-        config.set_setting("adding_content", "true")
-
         if overwrite == "everything":
             overwrite = True
             overwrite_everything = True
@@ -249,7 +239,6 @@ def check_for_update(overwrite=True):
                 t = float(100) / len(show_list)
 
             for i, tvshow_file in enumerate(show_list):
-
                 head_nfo, serie = library.read_nfo(tvshow_file)
                 path = filetools.dirname(tvshow_file)
 
@@ -316,10 +305,6 @@ def check_for_update(overwrite=True):
                     filetools.write(tvshow_file, head_nfo + serie.tojson())
 
                 if serie_actualizada:
-                    # Comprobar que no se esta buscando contenido en la biblioteca de Kodi
-                    while xbmc.getCondVisibility('Library.IsScanningVideo()'):
-                        xbmc.sleep(500)
-
                     # Actualizamos la biblioteca de Kodi
                     xbmc_library.update(folder=filetools.basename(path))
 
@@ -327,8 +312,6 @@ def check_for_update(overwrite=True):
 
         else:
             logger.info("No actualiza la biblioteca, está desactivado en la configuración de pelisalacarta")
-
-        config.set_setting("adding_content", "false")
 
     except Exception as ex:
         logger.error("Se ha producido un error al actualizar las series")
@@ -338,8 +321,6 @@ def check_for_update(overwrite=True):
 
         if p_dialog:
             p_dialog.close()
-
-        config.set_setting("adding_content", "false")
 
 
 if __name__ == "__main__":

--- a/python/main-classic/platformcode/xbmc_library.py
+++ b/python/main-classic/platformcode/xbmc_library.py
@@ -342,13 +342,9 @@ def update(content_type=FOLDER_TVSHOWS, folder=""):
     if not librarypath.endswith("/"):
         librarypath += "/"
 
-    if xbmc.getCondVisibility('Library.IsScanningVideo()'):
-        #p_dialog = platformtools.dialog_progress_bg('Esperando para iniciar la actualización de la colección', "Ya había una actualización de la colección en curso")
-        # Comprobar que no se esta buscando contenido en la biblioteca de Kodi
-        while xbmc.getCondVisibility('Library.IsScanningVideo()'):
-            #p_dialog.update(0, '')
-            xbmc.sleep(500)
-        #p_dialog.close()
+    # Comprobar que no se esta buscando contenido en la biblioteca de Kodi
+    while xbmc.getCondVisibility('Library.IsScanningVideo()'):
+        xbmc.sleep(500)
 
     payload = {"jsonrpc": "2.0", "method": "VideoLibrary.Scan", "params": {"directory": librarypath}, "id": 1}
     data = get_data(payload)

--- a/python/main-classic/platformcode/xbmc_library.py
+++ b/python/main-classic/platformcode/xbmc_library.py
@@ -342,6 +342,14 @@ def update(content_type=FOLDER_TVSHOWS, folder=""):
     if not librarypath.endswith("/"):
         librarypath += "/"
 
+    if xbmc.getCondVisibility('Library.IsScanningVideo()'):
+        #p_dialog = platformtools.dialog_progress_bg('Esperando para iniciar la actualización de la colección', "Ya había una actualización de la colección en curso")
+        # Comprobar que no se esta buscando contenido en la biblioteca de Kodi
+        while xbmc.getCondVisibility('Library.IsScanningVideo()'):
+            #p_dialog.update(0, '')
+            xbmc.sleep(500)
+        #p_dialog.close()
+
     payload = {"jsonrpc": "2.0", "method": "VideoLibrary.Scan", "params": {"directory": librarypath}, "id": 1}
     data = get_data(payload)
     logger.info("data: %s" % data)


### PR DESCRIPTION
Para la parte de la biblioteca propongo esto:

1) No entiendo que hace adding_content, no se que aporta. Veo que lo pone a true y false, pero no se para que vale. Me lo he cargado.
2) He motivo el wait al "update()" ya que allí se llama tanto en la actualización automática como cuando se hace manual, es decir, si se intenta añadir 2 series de forma muy rápida también bloqueará.

Se puede probar el punto 2 de forma muy sencilla. Partiendo siempre de un pelisalacarta configurado sin contenido:
1) Caso de añadir 2 series muy rápido (supongo que el más raro): Ir a un canal (ej: seriesblanco) y buscar "Anatomía de grey", añadirla. Empezará a escanear la biblioteca, pero no paramos, le damos hacia atrás y buscamos otra serie y la añades la biblioteca antes de que acabe la primera (es larga, y mi PC no es muy rápido, así que tampoco es que tenga que correr mucho, simplemente le he dado a velocidad normal "atrás, atrás, buscar, título, seleccionar serie, y añadir a biblioteca" cuando he llegado estaba Grey's Anatomy al 80%. Aquí se queda esperando hasta que acaba, y entonces procede a añadir esta serie.

2) Caso actualizción: Ponerle el contenido de la carpeta library con varias series y abrir Kodi. Empezará a scrapear la primera serie, mandará el json-rpc y hará el scraping de la 2º serie mientras Kodi está escaneando la primera, la segunda llega a update() y ahí bloquea hasta que la 1º finalice... y todos contentos.

